### PR TITLE
Typo: Remove duplicate word in docs/taskwarrior.html

### DIFF
--- a/html/docs/taskwarrior.html
+++ b/html/docs/taskwarrior.html
@@ -53,7 +53,7 @@
             <h3>Taskwarrior</h3>
             <p>
               Taskwarrior and Timewarrior are related, and work together using
-              using an <code>on-modify</code> hook script installed for Taskwarrior.
+              an <code>on-modify</code> hook script installed for Taskwarrior.
             </p>
 
             <p>


### PR DESCRIPTION
Just noticed the word "using" is present twice on the [Taskwarrior page](https://timewarrior.net/docs/taskwarrior.html) in the docs, so here's a fix.