### PR TITLE
Add MacPorts entry to distributions.json

### DIFF
--- a/data/distributions.json
+++ b/data/distributions.json
@@ -23,7 +23,13 @@
     "hook": "/usr/lib64/timew/ext/on-modify.timewarrior"
   },
   {
-    "name": "macOS",
+    "name": "macOS (MacPorts)",
+    "url": "https://ports.macports.org/port/timewarrior/",
+    "cmd": "port install timewarrior",
+    "hook": "/opt/local/share/doc/timew/ext/on-modify.timewarrior"
+  },
+  {
+    "name": "macOS (Homebrew)",
     "url": "https://formulae.brew.sh/formula/timewarrior",
     "cmd": "brew install timewarrior",
     "hook": "/opt/homebrew/share/doc/timew/ext/on-modify.timewarrior"

--- a/data/distributions.json
+++ b/data/distributions.json
@@ -23,16 +23,16 @@
     "hook": "/usr/lib64/timew/ext/on-modify.timewarrior"
   },
   {
-    "name": "macOS (MacPorts)",
-    "url": "https://ports.macports.org/port/timewarrior/",
-    "cmd": "port install timewarrior",
-    "hook": "/opt/local/share/doc/timew/ext/on-modify.timewarrior"
-  },
-  {
     "name": "macOS (Homebrew)",
     "url": "https://formulae.brew.sh/formula/timewarrior",
     "cmd": "brew install timewarrior",
     "hook": "/opt/homebrew/share/doc/timew/ext/on-modify.timewarrior"
+  },
+  {
+    "name": "macOS (MacPorts)",
+    "url": "https://ports.macports.org/port/timewarrior/",
+    "cmd": "port install timewarrior",
+    "hook": "/opt/local/share/doc/timew/ext/on-modify.timewarrior"
   },
   {
     "name": "Nix",


### PR DESCRIPTION
Rename existing macOS entry to "macOS (Homebrew)".  Add an entry "macOS (MacPorts)" with the relevant MacPorts URL, command, and hook path.

I generated the site and confirmed that the addition is formatted properly in the `/docs/install/` page.